### PR TITLE
Fix image in readme on mobile

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Check whether a website is up or down using the [isitup.org](https://isitup.org) API
 
-<img src="screenshot.png" width="833" height="350">
+<img src="screenshot.png" width="833">
 
 ## Install
 


### PR DESCRIPTION
On mobile, it looks weird if you set width _and_ height when the screen is narrower than the width. The width will be small and the height will remain big.

It is sufficient to set width.